### PR TITLE
Move task group depth to task system priority.

### DIFF
--- a/arbor/threading/threading.cpp
+++ b/arbor/threading/threading.cpp
@@ -1,59 +1,64 @@
 #include <atomic>
 
 #include <arbor/assert.hpp>
+#include <arbor/util/scope_exit.hpp>
 
-#include "threading.hpp"
+#include "threading/threading.hpp"
 
 using namespace arb::threading::impl;
 using namespace arb::threading;
 using namespace arb;
 
-task notification_queue::try_pop(int priority) {
+priority_task notification_queue::try_pop(int priority) {
     arb_assert(priority < (int)q_tasks_.size());
-    task tsk;
     lock q_lock{q_mutex_, std::try_to_lock};
-    if (!q_lock) return tsk;
-    auto& q = q_tasks_.at(priority);
-    if (!q.empty()) {
-        tsk = std::move(q.front());
-        q.pop_front();
+
+    if (q_lock) {
+        auto& q = q_tasks_.at(priority);
+        if (!q.empty()) {
+            priority_task ptsk(std::move(q.front()), priority);
+            q.pop_front();
+            return ptsk;
+        }
     }
-    return tsk;
+
+    return {};
 }
 
-task notification_queue::pop() {
-    task tsk;
+priority_task notification_queue::pop() {
     lock q_lock{q_mutex_};
+
     while (empty() && !quit_) {
         q_tasks_available_.wait(q_lock);
     }
-    for (auto it = q_tasks_.rbegin(); it != q_tasks_.rend(); ++it) {
-        if (!it->empty()) {
-            tsk = std::move(it->front());
-            it->pop_front();
-            break;
+    for (int pri = n_priority-1; pri>=0; --pri) {
+        auto& q = q_tasks_.at(pri);
+        if (!q.empty()) {
+            priority_task ptsk{std::move(q.front()), pri};
+            q.pop_front();
+            return ptsk;
         }
     }
-    return tsk;
+    return {};
 }
 
-bool notification_queue::try_push(task& tsk, int priority) {
-    arb_assert(priority < (int)q_tasks_.size());
+bool notification_queue::try_push(priority_task& ptsk) {
+    arb_assert(ptsk.priority < (int)q_tasks_.size());
     {
         lock q_lock{q_mutex_, std::try_to_lock};
         if (!q_lock) return false;
-        q_tasks_.at(priority).push_front(std::move(tsk));
-        tsk = 0;
+
+        q_tasks_.at(ptsk.priority).push_front(ptsk.release());
     }
     q_tasks_available_.notify_all();
     return true;
 }
 
-void notification_queue::push(task&& tsk, int priority) {
-    arb_assert(priority < (int)q_tasks_.size());
+void notification_queue::push(priority_task&& ptsk) {
+    arb_assert(ptsk.priority < (int)q_tasks_.size());
     {
         lock q_lock{q_mutex_};
-        q_tasks_.at(priority).push_front(std::move(tsk));
+        q_tasks_.at(ptsk.priority).push_front(ptsk.release());
     }
     q_tasks_available_.notify_all();
 }
@@ -73,42 +78,55 @@ bool notification_queue::empty() {
     return true;
 }
 
-void task_system::run_tasks_loop(int i){
+void task_system::run(priority_task ptsk) {
+    arb_assert(ptsk);
+    auto guard = util::on_scope_exit([pri = current_task_priority_] { current_task_priority_ = pri; });
+
+    current_task_priority_ = ptsk.priority;
+    ptsk.run();
+}
+
+void task_system::run_tasks_loop(int i) {
+    auto guard = util::on_scope_exit([] { current_task_queue_ = -1; });
+    current_task_queue_ = i;
+
     while (true) {
-        task tsk;
+        priority_task ptsk;
         // Loop over the levels of priority starting from highest to lowest
-        for (int depth = impl::max_task_depth-1; depth >= 0; depth--) {
+        for (int pri = n_priority-1; pri>=0; --pri) {
             // Loop over the threads trying to pop a task of the requested priority.
-            for (unsigned n = 0; n != count_; n++) {
-                tsk = q_[(i + n) % count_].try_pop(depth);
-                if (tsk) break;
+            for (unsigned n = 0; n<count_; ++n) {
+                ptsk = q_[(i + n) % count_].try_pop(pri);
+                if (ptsk) break;
             }
-            if (tsk) break;
+            if (ptsk) break;
         }
         // If a task can not be acquired, force a pop from the queue. This is a blocking action.
-        if (!tsk) tsk = q_[i].pop();
-        if (!tsk) break;
-        tsk();
+        if (!ptsk) ptsk = q_[i].pop();
+        if (!ptsk) break;
+
+        run(std::move(ptsk));
     }
 }
 
-void task_system::try_run_task(int i, int lowest_priority) {
-    auto nthreads = get_num_threads();
-    task tsk;
+void task_system::try_run_task(int lowest_priority) {
+    unsigned i = current_task_queue_+1==0? 0: current_task_queue_;
+    arb_assert(i>=0 && i<count_);
+
     // Loop over the levels of priority starting from highest to lowest_priority
-    for (int depth = impl::max_task_depth-1; depth >= lowest_priority; depth--) {
+    for (int pri = n_priority-1; pri>=lowest_priority; --pri) {
         // Loop over the threads trying to pop a task of the requested priority.
-        for (int n = 0; n != nthreads; n++) {
-            tsk = q_[(i + n) % nthreads].try_pop(depth);
-            if (tsk) {
-                tsk();
+        for (unsigned n = 0; n != count_; n++) {
+            if (auto ptsk = q_[(i + n) % count_].try_pop(pri)) {
+                run(std::move(ptsk));
                 return;
             }
         }
     }
 }
 
-thread_local int task_system::thread_depth_ = -1;
+thread_local int task_system::current_task_priority_ = -1;
+thread_local unsigned task_system::current_task_queue_ = -1;
 
 // Default construct with one thread.
 task_system::task_system(): task_system(1) {}
@@ -117,9 +135,14 @@ task_system::task_system(int nthreads): count_(nthreads), q_(nthreads) {
     if (nthreads <= 0)
         throw std::runtime_error("Non-positive number of threads in thread pool");
 
+    for (unsigned p = 0; p<n_priority; ++p) {
+        index_[p] = 0;
+    }
+
     // Main thread
     auto tid = std::this_thread::get_id();
     thread_ids_[tid] = 0;
+    current_task_queue_ = 0;
 
     for (unsigned i = 1; i < count_; i++) {
         threads_.emplace_back([this, i]{run_tasks_loop(i);});
@@ -129,31 +152,25 @@ task_system::task_system(int nthreads): count_(nthreads), q_(nthreads) {
 }
 
 task_system::~task_system() {
+    current_task_priority_ = -1;
+    current_task_queue_ = -1;
     for (auto& e: q_) e.quit();
     for (auto& e: threads_) e.join();
-    set_thread_depth(-1);
 }
 
-void task_system::async(task tsk, int priority) {
-    arb_assert(priority < (int)index_.size());
-    auto i = index_[priority]++;
-
-    for (unsigned n = 0; n != count_; n++) {
-        if (q_[(i + n) % count_].try_push(tsk, priority)) return;
+void task_system::async(priority_task ptsk) {
+    if (ptsk.priority>=n_priority) {
+        run(std::move(ptsk));
     }
-    q_[i % count_].push(std::move(tsk), priority);
-}
+    else {
+        arb_assert(ptsk.priority < (int)index_.size());
+        auto i = index_[ptsk.priority]++;
 
-int task_system::get_num_threads() const {
-    return threads_.size() + 1;
-}
-
-int task_system::get_thread_depth() {
-    return thread_depth_;
-}
-
-void task_system::set_thread_depth(int depth) {
-    thread_depth_ = depth;
+        for (unsigned n = 0; n != count_; n++) {
+            if (q_[(i + n) % count_].try_push(ptsk)) return;
+        }
+        q_[i % count_].push(std::move(ptsk));
+    }
 }
 
 std::unordered_map<std::thread::id, std::size_t> task_system::get_thread_ids() const {

--- a/test/unit/test_thread.cpp
+++ b/test/unit/test_thread.cpp
@@ -96,7 +96,7 @@ TEST(notification_queue, test_copy) {
     notification_queue q;
 
     ftor f;
-    q.push(f, 0);
+    q.push({task(f), 0});
 
     // Copy into new ftor and move ftor into a task (std::function<void()>)
     EXPECT_EQ(1, nmove);
@@ -110,7 +110,7 @@ TEST(notification_queue, test_move) {
     ftor f;
 
     // Move into new ftor and move ftor into a task (std::function<void()>)
-    q.push(std::move(f), 1);
+    q.push({task(std::move(f)), 1});
     EXPECT_LE(nmove, 2);
     EXPECT_LE(ncopy, 1);
     reset();


### PR DESCRIPTION
* Package task and task priority into combined wrapper with move/release semantics.
* Set task system thread-local current task priority when executing task.
* Run tasks with higher than maximum priority synchronously, and devolve the synchronous/asynchronous run choice from the task group to the task system.
* Set the tasks scheduled by a task group default to one more than the current task priority.